### PR TITLE
Updated to i586 with a i686 overlay

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,4 +37,5 @@ jobs:
 
       - name: Verify installed binaries
         run: |
-          /opt/win32/bin/i686-w64-mingw32-gcc --version
+          /opt/win32/bin/i586-w64-mingw32-gcc --version
+          /opt/win32/bin/i586-w64-mingw32-g++ --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,3 +39,5 @@ jobs:
         run: |
           /opt/win32/bin/i586-w64-mingw32-gcc --version
           /opt/win32/bin/i586-w64-mingw32-g++ --version
+          /opt/win32/bin/i686-w64-mingw32-gcc --version
+          /opt/win32/bin/i686-w64-mingw32-g++ --version

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 
 # MinGW32 MSVCRT Toolchain
 
-`i586-w64-mingw32` cross-compiler toolchain using **MSVCRT** as default runtime. 
+cross-compiler toolchain using **MSVCRT** as default runtime.
+Default target: `i586-w64-mingw32`. Optional overlay: `i686-w64-mingw32`.
+
 Ideal for compiling binaries compatible with **Windows 95/98/ME, 2000, XP** and other old systems, avoiding UCRT, while allowing **SSE2 and AVX** for modern CPUs when desired.
 
 ## 🎯 Objective
@@ -119,6 +121,12 @@ AVX needs an OS that saves/restores  YMM state. **Windows XP does not**; think W
 ```bash
 i586-w64-mingw32-g++ main.cpp -o main.exe -static-libgcc -static-libstd++
 ```
+
+# i686 overlay builds:
+```bash
+i686-w64-mingw32-gcc main.c -o main.exe
+```
+**Uses `--with-arch=pentiumpro` internally for i686 optimizations**
 
 Example with Legacy flags:
 ```bash

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 
 # MinGW32 MSVCRT Toolchain
 
-`i686-w64-mingw32` cross-compiler toolchain using **MSVCRT** as default runtime. Ideal for compiling binaries compatible with Windows 9x, 2000, XP and other old systems, avoiding UCRT.
+`i586-w64-mingw32` cross-compiler toolchain using **MSVCRT** as default runtime. 
+Ideal for compiling binaries compatible with **Windows 95/98/ME, 2000, XP** and other old systems, avoiding UCRT, while allowing **SSE2 and AVX** for modern CPUs when desired.
 
 ## 🎯 Objective
 
@@ -19,6 +20,11 @@ Build a clean and minimalist MinGW32 toolchain with:
 - mingw-w64 CRT (with MSVCRT)
 - gcc (phase 2 - according to mingw32 to make Toolchains or Canadian Cross, is necessary to make GCC in two phases)
 - mingw-w64 tools (gendef, genidl, genpeimg, widl)
+
+Supports:
+
+- **Legacy Windows** (95/98/ME/NT4/2000/XP)
+- **Modern CPU features** (SSE2, AVX) for newer systems, selectable per-project.
 
 ## ✅ Prerequisites
 
@@ -78,16 +84,51 @@ export PATH=$PREFIX/bin:$PATH
 edit accordingly your PREFIX configuration
 ```
 
-Example of compilation:
+⚡ Using the Compiler:
+
+## Legacy-safe builds (Win9x/98/ME/NT4) - default, nothing speial:
 
 ```bash
-i686-w64-mingw32-gcc -nostdlib -static-libgcc -lmingw32 hello.c -o hello.exe
+i586-w64-mingw32-gcc main.c -o main.exe
+```
+
+## Win2000+:
+```bash
+i586-w64-mingw32-gcc main.c -o main.exe -DWINVER=0x500 -D_WIN32_WINNT=0x500
+```
+
+## WinXP+"
+```bash
+i586-w64-mingw32-gcc main.c -o main.exe -DWINVER=0x501 -D_WIN32_WINNT=0x501
+```
+
+## Enable SSE2 (Pentium 4+):
+```bash
+i586-w64-mingw32-gcc main.c -o main.exe -msse2 -mfpmath=sse
+```
+(Will **not** run on 9x/NT4-era hardware.)
+
+# Enable AVX (Sandy Bridge+ and OS support):
+
+```bash
+i586-w64-mingw32-gcc main.c -o main.exe -mavx
+```
+AVX needs an OS that saves/restores  YMM state. **Windows XP does not**; think Windows 7 SP1+.
+
+# C++ small/static Runtime if desired:
+```bash
+i586-w64-mingw32-g++ main.cpp -o main.exe -static-libgcc -static-libstd++
+```
+
+Example with Legacy flags:
+```bash
+i586-w64-mingw32-gcc -nostdlib -static-libgcc -lmingw32 hello.c -o hello.exe
 ```
 
 ## 🖼️ Compatibility
 
 - Generate code for Windows 95/98/ME/2k/XP
-- Compatible with Windows NT 4.0/2k/XP
+- Compatible with Windows NT4/2000/XP
 - Don't Work with UCRT (but you have to test it)
 - Works with MSVCRT (tested)
 
@@ -98,3 +139,13 @@ This project only automates compilations of GNU tools under their respective lic
 ## 📄 Note
 
 This repository is part of a complex project comming soon early
+
+## 🗂️ Feature Matrix
+
+| Target Windows | Compiler Flag | CPU Features | Notes |
+|----------------|---------------|--------------|-------|
+| Windows 95/98/ME | `i586-w64-mingw32-gcc` | Pentium / MMX | Legacy safe |
+| Windows NT4/2000 | `-DWINVER=0x0500 -D_WIN32_WINNT=0x0500` | SSE optional | Modern CPUs can enable SSE2 |
+| Windows XP | `-DWINVER=0x0501 -D_WIN32_WINNT=0x0501` | SSE2 default | Works on most XP-era CPUs |
+| Windows 7+ | `-DWINVER=0x0601 -D_WIN32_WINNT=0x0601` | SSE2 / AVX optional | Enable AVX with `-mavx` |
+| Modern CPUs | `-msse2 -mavx` | SSE2 / AVX | Only for CPUs that support it, may break legacy Windows |

--- a/compile-mingw32.sh
+++ b/compile-mingw32.sh
@@ -13,9 +13,15 @@ THREADS="--enable-threads=win32"
 TC_ARCH="win32"
 BUILD_DIR="/opt/$TC_ARCH"
 PREFIX="$BUILD_DIR"
-TARGET="i686-w64-mingw32"
+TARGET="i586-w64-mingw32" # Pentium baseline (safe for Win95/NT4)
 JOBS="$(nproc)"
 SOURCE="src-$TC_ARCH"
+
+###########################################################################
+# Default to NT4/Win95 headersl override per-project of you need 2000/XP+ #
+###########################################################################
+CFLAGS+="-DWINVER=0x0400 -D_WIN32_WINNT=0x0400"
+CXXFLAGS+="$CFLAGS"
 
 #########################
 # URLs of sources files #
@@ -129,7 +135,13 @@ HOST=$(~/$SOURCE/gcc-13.1.0/config.guess)
 echo "Starting Binutils build..."
 cd binutils-${BINUTILS_VER}
 mkdir -p build && cd build
-../configure --target=$TARGET --host=$HOST --prefix=$PREFIX --with-sysroot=$PREFIX --disable-multilib --disable-nls
+../configure \
+   --target=$TARGET \
+   --host=$HOST \
+   --prefix=$PREFIX \
+   --with-sysroot=$PREFIX \
+   --disable-multilib \
+   --disable-nls
 make -j$JOBS
 make install
 
@@ -147,12 +159,18 @@ mkdir -p build && cd build
 # as per Mingw/GCC documentation for Toolchain #
 ################################################
 
-../configure --prefix=$PREFIX/$TARGET --host=$TARGET --with-sysroot=$PREFIX --enable-sdk=all --enable-idl --with-default-msvcrt=msvcrt
+../configure \
+   --prefix=$PREFIX/$TARGET \
+   --host=$TARGET \
+   --with-sysroot=$PREFIX \
+   --enable-sdk=all \
+   --enable-idl \
+   --with-default-msvcrt=msvcrt
 make install
 
 echo "Creating Symlinks"
-ln -s $PREFIX/$TARGET $PREFIX/mingw
-ln -s $PREFIX/$TARGET/lib $PREFIX/$TARGET/lib64
+ln -sf $PREFIX/$TARGET $PREFIX/mingw
+ln -sf $PREFIX/$TARGET/lib $PREFIX/$TARGET/lib64
 echo ""
 echo "Now mingw and lib64 is symlinked" 
 echo "to correct paths accepted by GCC"
@@ -176,15 +194,28 @@ cd ~/$SOURCE/gcc-${GCC_VER}
 # Download GCC Pre Requisites
 echo "Downloading GCC Pre Requisites"
 ./contrib/download_prerequisites
-mkdir -p build && cd build
+mkdir -p build-phase-1 && cd build-phase-1
 
 ##########################################
 # Configure GGC for Phase 1              # 
 # as per GCC documentation for Toolchain #
 ##########################################
 echo "Building GCC ${GCC_VERSION} with C only"
-# Building with c++ cause errors about SSE2 and AVX, help to fix that is appreciated
-../configure --target=$TARGET --host=$HOST --prefix=$PREFIX --with-sysroot=$PREFIX --disable-multilib --enable-languages=c --disable-nls --without-headers --with-default-msvcrt=msvcrt --disable-shared $THREADS
+../configure \
+   --target=$TARGET \
+   --host=$HOST \
+   --prefix=$PREFIX \
+   --with-sysroot=$PREFIX \
+   --disable-multilib \
+   --enable-languages=c \
+   --disable-nls \
+   --without-headers \
+   --with-default-msvcrt=msvcrt \
+   --disable-shared \
+   --with-arch=pentium \
+   --with-tune=generic \
+   --enable-sjlj-exceptions \
+   $THREADS
 make all-gcc -j$JOBS
 make install-gcc
 
@@ -202,7 +233,11 @@ mkdir -p build && cd build
 # as per Mingw/GCC documentation for Toolchain #
 ################################################
 
-../configure --host=$TARGET --prefix=$PREFIX/$TARGET --with-sysroot=$PREFIX --with-default-msvcrt=msvcrt
+../configure \
+   --host=$TARGET \
+   --prefix=$PREFIX/$TARGET \
+   --with-sysroot=$PREFIX \
+   --with-default-msvcrt=msvcrt
 make -j$JOBS
 make install
 
@@ -210,7 +245,21 @@ make install
 # Built GCC Phase 2 (Continues the Phase 1 #
 ############################################
 echo "Building GCC ${GCC_VER} Phase 2"
-cd ~/$SOURCE/gcc-13.1.0/build
+cd ~/$SOURCE/gcc-13.1.0
+mkdir -p build-phase-2 && cd build-phase-2
+../configure \
+   --target=$TARGET \
+   --host=$HOST \
+   --prefix=$PREFIX \
+   --with-sysroot=$PREFIX \
+   --disable-multilib \
+   --enable-languages=c,c++ \
+   --disable-nls \
+   --disable-shared \
+   --with-arch=pentium \
+   --with-tune=generic \
+   --enable-sjlj-exceptions \
+   $THREADS
 
 ##########################################
 # Configure GGC for Phase 2              #
@@ -230,29 +279,24 @@ make install
 
 echo "Building Mingw-w64 tools"
 
-echo "Building gendef"
-cd ~/$SOURCE/mingw-w64-v12.0.0/mingw-w64-tools/gendef
-./configure
-make -j$JOBS
-make install
+build_tool() {
+	local tool=$1
+	echo "Building $tool"
+	
+	cd ~/$SOURCE/mingw-w64-v12.0.0/mingw-w64-tools/$tool
+	if [ "$tool" == "widl" ]; then
+		./configure --target=$TARGET --prefix=$PREFIX --bindir=$PREFIX/bin
+	else
+		./configure
+	fi
+	make -j$JOBS
+	make install
+}
 
-echo "Building genidl"
-cd ~/$SOURCE/mingw-w64-v12.0.0/mingw-w64-tools/genidl
-./configure
-make -j$JOBS
-make install
-
-echo "Building genpeimg"
-cd ~/$SOURCE/mingw-w64-v12.0.0/mingw-w64-tools/genpeimg
-./configure
-make -j$JOBS
-make install
-
-echo "Building widl"
-cd ~/$SOURCE/mingw-w64-v12.0.0/mingw-w64-tools/widl
-./configure --target=$TARGET --prefix=$PREFIX --bindir=$PREFIX/bin
-make -j$JOBS
-make install
+build_tool gendef
+build_tool genidl
+build_tool genpeimg
+build_tool widl
 
 echo "Built all done! Toolchain is located in $TARGET"
 echo "Don't forget to add the $TARGET in PATH to use"

--- a/compile-mingw32.sh
+++ b/compile-mingw32.sh
@@ -14,6 +14,7 @@ TC_ARCH="win32"
 BUILD_DIR="/opt/$TC_ARCH"
 PREFIX="$BUILD_DIR"
 TARGET="i586-w64-mingw32" # Pentium baseline (safe for Win95/NT4)
+I686_TARGET="i686-w64-mingw32" # i686 overlay for 200/XP+
 JOBS="$(nproc)"
 SOURCE="src-$TC_ARCH"
 
@@ -297,6 +298,47 @@ build_tool gendef
 build_tool genidl
 build_tool genpeimg
 build_tool widl
+
+#########################
+# Optional i686 overlay #
+#########################
+
+################################################
+# Build and install Binutils 2.40 i686 overlay #
+################################################
+echo "Starting Binutils i686 build..."
+cd ~/$SOURCE/binutils-${BINUTILS_VER}
+mkdir -p build-i686 && cd build-i686
+../configure \
+	--target=$I686_TARGET \
+	--host=$HOST \
+	--prefix=$PREFIX \
+	--disable-multilib \
+	--disable-nls
+make -j$JOBS
+make install
+
+#############################################
+# Build and install GCC 13.1.0 i686 overlay #
+#############################################
+echo "Starting GCC ${GCC_VER} i686 build ..."
+cd ~/$SOURCE/gcc-${GCC_VER}
+mkdir build-i686 && cd build-i686
+../configure \
+	--target=$I686_TARGET \
+	--host=$HOST \
+	--prefix=$PREFIX \
+	--with-sysroot=$PREFIX \
+	--disable-multilib \
+	--enable-languages=c,c++ \
+	--disable-nls \
+	--disable-shared \
+	--with-arch=pentiumpro \
+	--with-tune=generic \
+	--enable-sjlj-exceptions \
+	$THREADS
+make all-gcc -j$JOBS
+make install-gcc
 
 echo "Built all done! Toolchain is located in $TARGET"
 echo "Don't forget to add the $TARGET in PATH to use"


### PR DESCRIPTION
I've updated the script and readme files to make i586 for Windows 95/98/ME and NT4, and i686 is the overlay to compile for Windows 2000 and XP+